### PR TITLE
Frontend new note

### DIFF
--- a/client/src/components/Content/Content.js
+++ b/client/src/components/Content/Content.js
@@ -25,6 +25,7 @@ class Content extends React.Component {
             {/* For testing */}
             {console.log("Getting user info from firebase...")}
             {console.log(authUser)}
+            {console.log(authUser.email)}
             <div>
               {this.props.selectedNote}
             </div>

--- a/client/src/components/DeleteAlert/DeleteAlert.js
+++ b/client/src/components/DeleteAlert/DeleteAlert.js
@@ -1,0 +1,54 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { withStyles } from '@material-ui/core/styles';
+import Snackbar from '@material-ui/core/Snackbar';
+import IconButton from '@material-ui/core/IconButton';
+import CloseIcon from '@material-ui/icons/Close';
+
+const styles = theme => ({
+  close: {
+    padding: theme.spacing.unit / 2,
+  },
+});
+
+class DeleteAlert extends Component {
+
+  render() {
+    const { classes } = this.props;
+    return (
+      <div>
+        <Snackbar
+          className={classes.alert}
+          anchorOrigin={{
+            vertical: 'bottom',
+            horizontal: 'left',
+          }}
+          open={this.props.deleteAlertOpen}
+          autoHideDuration={2000}
+          onClose={this.props.handleAlertClose}
+          ContentProps={{
+            'aria-describedby': 'message-id',
+          }}
+          message={<span id="message-id">Note deleted</span>}
+          action={[
+            <IconButton
+              key="close"
+              aria-label="Close"
+              color="inherit"
+              className={classes.close}
+              onClick={this.props.handleAlertClose}
+            >
+              <CloseIcon />
+            </IconButton>,
+          ]}
+        />
+      </div>
+    );
+  }
+}
+
+DeleteAlert.propTypes = {
+  classes: PropTypes.object.isRequired,
+};
+
+export default withStyles(styles)(DeleteAlert);

--- a/client/src/components/LeftDrawer/LeftDrawer.js
+++ b/client/src/components/LeftDrawer/LeftDrawer.js
@@ -61,6 +61,8 @@ const styles = theme => ({
   },
   drawerPaper: {
     position: 'relative',
+    display: 'block',
+    // width: '100%',
     // width: drawerWidth,
     [theme.breakpoints.down('sm')]: {
       width: '100%'
@@ -68,9 +70,20 @@ const styles = theme => ({
     [theme.breakpoints.up('md')]: {
       width: '240px'
     },
-    height: '100vh' // Needed if removing root/ app divs
+    height: '100vh'
+  },
+  headerPaper: {
+    position: 'relative',
+    display: 'block',
+    [theme.breakpoints.down('sm')]: {
+      width: '100%'
+    },
+    [theme.breakpoints.up('md')]: {
+      width: '240px'
+    },
   },
   drawerHeaderL: {
+    // position: 'absolute',
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'flex-end',
@@ -109,7 +122,8 @@ class LeftDrawer extends Component {
       title: this.state.title,
       body: this.state.body
     })
-      .then(this.child.current.loadNotes());
+      // .then(this.child.current.loadNotes());
+      .then(this.child.current.refreshNewNote());
   };
 
   render() {
@@ -117,22 +131,6 @@ class LeftDrawer extends Component {
 
     const drawer = (
       <>
-        <div className={classes.drawerHeaderL}>
-          <IconButton>
-            <Add 
-              title={this.state.title}
-              body={this.state.body}
-              onClick={this.handleNewNote}/>
-          </IconButton>
-            Left Drawer
-          <IconButton onClick={this.props.handleLeftDrawer}>
-            <Close style={{
-                width: 15,
-                height: 15
-              }}
-            />
-          </IconButton>
-        </div>
         <Divider/>
         <NoteList
           notes={this.state.notes}
@@ -140,6 +138,25 @@ class LeftDrawer extends Component {
           innerRef={this.child}
         />
       </>
+    )
+
+    const header = (
+      <div className={classes.drawerHeaderL}>
+        <IconButton>
+          <Add 
+            title={this.state.title}
+            body={this.state.body}
+            onClick={this.handleNewNote}/>
+        </IconButton>
+          Left Drawer
+        <IconButton onClick={this.props.handleLeftDrawer}>
+          <Close style={{
+              width: 15,
+              height: 15
+            }}
+          />
+        </IconButton>
+      </div>
     )
 
     return (
@@ -152,6 +169,7 @@ class LeftDrawer extends Component {
               paper: classes.drawerPaper,
             }}
           >
+            {header}
             {drawer}
           </Drawer>
         </Hidden>
@@ -161,9 +179,19 @@ class LeftDrawer extends Component {
               variant="persistent"
               open={this.props.leftOpen}
               classes={{
+                paper: classes.headerPaper,
+              }}
+            >
+              {header}
+            </Drawer>
+            <Drawer
+              variant="persistent"
+              open={this.props.leftOpen}
+              classes={{
                 paper: classes.drawerPaper,
               }}
             >
+              {/* {header} */}
               {drawer}
             </Drawer>
         </Hidden>

--- a/client/src/components/LeftDrawer/LeftDrawer.js
+++ b/client/src/components/LeftDrawer/LeftDrawer.js
@@ -101,7 +101,6 @@ class LeftDrawer extends Component {
   //   // this.loadNotes();
   // }
 
-
   // new note doesn't update the note list until the drawer is closed and opened again
   handleNewNote () {
     console.log("Hit handleNewNote function");
@@ -113,13 +112,6 @@ class LeftDrawer extends Component {
     })
       .then(this.child.current.loadNotes());
   };
-
-  // loadNotes = () => {
-  //   console.log('Ran loadNotes function from LeftDrawer.js.')
-  //   API.getNotes()
-  //     .then(res => this.setState({ notes: res.data }))
-  //     .catch(err => console.log(err));
-  // };
 
   render() {
     const { classes } = this.props;
@@ -144,9 +136,9 @@ class LeftDrawer extends Component {
         </div>
         <Divider/>
         <NoteList
-          ref={this.child}
           notes={this.state.notes}
           handleSelectedNote={this.handleSelectedNote}
+          innerRef={this.child}
         />
       </>
     )

--- a/client/src/components/LeftDrawer/LeftDrawer.js
+++ b/client/src/components/LeftDrawer/LeftDrawer.js
@@ -91,7 +91,6 @@ class LeftDrawer extends Component {
   constructor(props) {
     super(props);
     this.handleNewNote = this.handleNewNote.bind(this);
-    // this.loadNotes = this.loadNotes.bind(this);
     this.handleSelectedNote = this.props.handleSelectedNote.bind(this);
     this.child = React.createRef();
   }
@@ -147,7 +146,6 @@ class LeftDrawer extends Component {
         <>
         <Hidden mdUp>
           <Drawer
-            // anchor="left"
             variant="temporary"
             open={this.props.leftOpen}
             classes={{

--- a/client/src/components/LeftDrawer/LeftDrawer.js
+++ b/client/src/components/LeftDrawer/LeftDrawer.js
@@ -93,12 +93,13 @@ class LeftDrawer extends Component {
     this.handleNewNote = this.handleNewNote.bind(this);
     // this.loadNotes = this.loadNotes.bind(this);
     this.handleSelectedNote = this.props.handleSelectedNote.bind(this);
+    this.child = React.createRef();
   }
 
-  componentDidMount() {
-    console.log("LeftDrawer.js componentDidMount()");
-    // this.loadNotes();
-  }
+  // componentDidMount() {
+  //   console.log("LeftDrawer.js componentDidMount()");
+  //   // this.loadNotes();
+  // }
 
 
   // new note doesn't update the note list until the drawer is closed and opened again
@@ -110,9 +111,7 @@ class LeftDrawer extends Component {
       title: this.state.title,
       body: this.state.body
     })
-      // .then(res => this.loadNotes())
-      // .then(res => this.forceUpdate())
-      // .catch(err => console.log(err));
+      .then(this.child.current.loadNotes());
   };
 
   // loadNotes = () => {
@@ -145,6 +144,7 @@ class LeftDrawer extends Component {
         </div>
         <Divider/>
         <NoteList
+          ref={this.child}
           notes={this.state.notes}
           handleSelectedNote={this.handleSelectedNote}
         />

--- a/client/src/components/LeftDrawer/LeftDrawer.js
+++ b/client/src/components/LeftDrawer/LeftDrawer.js
@@ -105,6 +105,7 @@ class LeftDrawer extends Component {
     super(props);
     this.handleNewNote = this.handleNewNote.bind(this);
     this.handleSelectedNote = this.props.handleSelectedNote.bind(this);
+    this.handleDeleteAlert = this.props.handleDeleteAlert.bind(this);
     this.child = React.createRef();
   }
 
@@ -135,6 +136,7 @@ class LeftDrawer extends Component {
         <NoteList
           notes={this.state.notes}
           handleSelectedNote={this.handleSelectedNote}
+          handleDeleteAlert={this.props.handleDeleteAlert}
           innerRef={this.child}
         />
       </>

--- a/client/src/components/NoteList/NoteList.js
+++ b/client/src/components/NoteList/NoteList.js
@@ -11,7 +11,8 @@ import ListItemIcon from '@material-ui/core/ListItemIcon';
 import ListItemText from '@material-ui/core/ListItemText';
 import ClickAwayListener from '@material-ui/core/ClickAwayListener';
 import Popover from '@material-ui/core/Popover';
-
+import Layers from '@material-ui/icons/Layers';
+import InputAdornment from '@material-ui/core/InputAdornment';
 
 const styles = theme => ({
   root: {
@@ -19,6 +20,7 @@ const styles = theme => ({
   },
   paper: {
     marginRight: theme.spacing.unit * 2,
+    justifyContent: 'flex-end',
   },
   menuItem: {
     '&:focus': {
@@ -30,6 +32,10 @@ const styles = theme => ({
   },
   primary: {},
   icon: {},
+  noteField: {
+    justifyContent: 'flex-end',
+    width: '100%'
+  },
 });
 
 class NoteList extends Component {
@@ -133,6 +139,26 @@ class NoteList extends Component {
       .catch(err => console.log(err));
   }
 
+  refreshNewNote = () => {
+    console.log('Ran refreshNewNote function from NoteList.js.');
+    API.getNotes()
+      .then(res => this.setState({ notes: res.data }))
+      .catch(err => console.log(err));
+
+    setTimeout(
+      function() {
+        let edit = this.state.isEditable.map((val) => {
+          return (val = false);
+        });
+        let isEditable = edit.slice();
+        isEditable[0] = true;
+        this.setState({ isEditable });
+      }
+      .bind(this),
+      270
+    );
+  }
+
   // need to select the "next" note when one note is deleted, otherwise the body stays the same
   deleteNote = (event, id) => {
     console.log('Delete method called.');
@@ -162,6 +188,7 @@ class NoteList extends Component {
             {this.state.isEditable[index] ? (
               // Editable text field
               <TextField
+                className={classes.noteField}
                 key={note._id}
                 autoFocus
                 onFocus={this.handleFocus}
@@ -170,13 +197,26 @@ class NoteList extends Component {
                 onChange={(e) => this.handleChange(e, note._id, index)}
                 onBlur={(e) => this.handleBlur(e, note._id, index)}
                 onKeyDown={(e) => this.keyPress(e, note._id, index)}
+                InputProps={{
+                  startAdornment: (
+                    <InputAdornment position="start">
+                      <Layers />
+                    </InputAdornment>
+                  ),
+                }}
               />
             ) : (
               // Read only text field
               <TextField
+                className={classes.noteField}
                 key={note._id}
                 InputProps={{
                   readOnly: true,
+                  startAdornment: (
+                    <InputAdornment position="start">
+                      <Layers />
+                    </InputAdornment>
+                  ),
                 }}
                 defaultValue={note.title}
                 onClick={() => this.props.handleSelectedNote(note.body)}
@@ -184,7 +224,6 @@ class NoteList extends Component {
                 aria-owns={open ? 'simple-menu' : null}
                 aria-haspopup="true"
                 onContextMenu={(e) => this.handleContextMenu(e, note._id)}
-                // onClickAway={this.handleClose}
               />
             )}
           </>

--- a/client/src/components/NoteList/NoteList.js
+++ b/client/src/components/NoteList/NoteList.js
@@ -155,7 +155,7 @@ class NoteList extends Component {
         this.setState({ isEditable });
       }
       .bind(this),
-      270
+      310
     );
   }
 

--- a/client/src/components/NoteList/NoteList.js
+++ b/client/src/components/NoteList/NoteList.js
@@ -165,6 +165,7 @@ class NoteList extends Component {
     this.handleClose(event);
     API.deleteNote(id)
       .then(res => this.loadNotes())
+      // .then(this.props.handleDeleteAlert())
       .catch(err => console.log(err));
   }
  
@@ -176,7 +177,6 @@ class NoteList extends Component {
       positionTop,
       positionLeft,
     } = this.state;
-    
 
     return(
       <>
@@ -256,7 +256,9 @@ class NoteList extends Component {
               </ListItemIcon>
               <ListItemText classes={{ primary: classes.primary }} inset primary="Share"/>
             </MenuItem>
-            <MenuItem className={classes.menuitem} onClick={(e) => this.deleteNote(e, targetId)}>
+            <MenuItem 
+              className={classes.menuitem}
+              onClick={(e) => { this.deleteNote(e, targetId); this.props.handleDeleteAlert(); }}>
               <ListItemIcon className={classes.icon}>
                 <DeleteIcon/>
               </ListItemIcon>

--- a/client/src/components/Page/MainPage.js
+++ b/client/src/components/Page/MainPage.js
@@ -5,6 +5,7 @@ import LeftDrawer from '../LeftDrawer/LeftDrawer'
 import RightDrawer from '../RightDrawer/RightDrawer';
 import Grid from '@material-ui/core/Grid';
 import Content from '../Content/Content';
+import DeleteAlert from '../DeleteAlert/DeleteAlert';
 
 // import Typography from '@material-ui/core/Typography';
 // import AuthUserContext from '../AuthUserContext';
@@ -34,7 +35,8 @@ class MainPage extends React.Component {
       // authUser: null,
       leftOpen: true,
       rightOpen: false,
-      selectedNote: 'start'
+      selectedNote: 'start',
+      deleteAlertOpen: false
     };
   }
 
@@ -62,6 +64,20 @@ class MainPage extends React.Component {
     })
   }
 
+  handleDeleteAlert = () => {
+    console.log("Delete alert function fired.");
+    this.setState({
+      deleteAlertOpen: true
+    })
+  }
+
+  handleAlertClose = (event, reason) => {
+    if (reason === 'clickaway') {
+      return;
+    }
+    this.setState({ deleteAlertOpen: false });
+  };
+
   // componentDidMount() {
   //   firebase.auth.onAuthStateChanged(authUser => {
   //     authUser
@@ -83,12 +99,17 @@ class MainPage extends React.Component {
               handleLeftDrawer={this.handleLeftDrawer}
               handleRightDrawer={this.handleRightDrawer}
             />
+            <DeleteAlert
+              deleteAlertOpen={this.state.deleteAlertOpen}
+              handleAlertClose={this.handleAlertClose}
+            />
             <Grid container>
               <Grid item md={2}>
                 <LeftDrawer
                   leftOpen={this.state.leftOpen}
                   handleLeftDrawer={this.handleLeftDrawer}
                   handleSelectedNote={this.handleSelectedNote}
+                  handleDeleteAlert={this.handleDeleteAlert}
                 />
               </Grid>
 


### PR DESCRIPTION
-creating a new note now auto focuses on the new title field\\
-right click on note title to open a menu with Share and Delete options. Delete works, Share has no function yet. Menu opens at cursor
-After deleting a note, an alert appears in the bottom left confirming the delete
-Note list in the sidebar now scrolls correctly when there are lots of notes. The header is actually a distinct drawer now (so that it doesn't scroll along with the notes)