### PR TITLE
Patch two

### DIFF
--- a/client/src/components/LeftDrawer/LeftDrawer.js
+++ b/client/src/components/LeftDrawer/LeftDrawer.js
@@ -6,7 +6,7 @@ import IconButton from '@material-ui/core/IconButton';
 import SharedNotes from "../SharedNotes/SharedNotes"
 import AddSharp from '@material-ui/icons/AddSharp';
 import VerticalAlignBottomSharp from '@material-ui/icons/VerticalAlignBottomSharp';
-
+import Tooltip from '@material-ui/core/Tooltip';
 import NoteList from '../NoteList/NoteList';
 import Hidden from '@material-ui/core/Hidden';
 import Divider from '@material-ui/core/Divider';
@@ -173,22 +173,26 @@ class LeftDrawer extends Component {
 
     const header = (
       <div className={classes.drawerHeaderL} style={{ minHeight: '34px', maxHeight: '34px'}}>
-        <IconButton 
-          className={classes.menuButton}
-          onClick={this.handleNewNote}>
-          <AddSharp
-            title={this.state.title}
-            body={this.state.body}/>
-        </IconButton>
-        <IconButton 
-          className={classes.menuButton}
-          onClick={this.props.handleLeftDrawer}>
-          <VerticalAlignBottomSharp
-            style={{
-              transform: 'rotate(90deg)',
-            }}
-          />
-        </IconButton>
+        <Tooltip title="New note">
+          <IconButton 
+            className={classes.menuButton}
+            onClick={this.handleNewNote}>
+            <AddSharp
+              title={this.state.title}
+              body={this.state.body}/>
+          </IconButton>
+        </Tooltip>
+        <Tooltip title="Close notes panel">
+          <IconButton 
+            className={classes.menuButton}
+            onClick={this.props.handleLeftDrawer}>
+            <VerticalAlignBottomSharp
+              style={{
+                transform: 'rotate(90deg)',
+              }}
+            />
+          </IconButton>
+        </Tooltip>
       </div>
     )
 

--- a/client/src/components/LeftDrawer/LeftDrawer.js
+++ b/client/src/components/LeftDrawer/LeftDrawer.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';
 import Drawer from '@material-ui/core/Drawer';
 import IconButton from '@material-ui/core/IconButton';
-import SharedNotes from "../SharedNotes/SharedNotes"
+import SharedNotes from '../SharedNotes/SharedNotes';
 import AddSharp from '@material-ui/icons/AddSharp';
 import VerticalAlignBottomSharp from '@material-ui/icons/VerticalAlignBottomSharp';
 import Tooltip from '@material-ui/core/Tooltip';
@@ -13,11 +13,6 @@ import Divider from '@material-ui/core/Divider';
 
 import API from '../../utils/API';
 import {firebase} from "../../firebase";
-
-// import { Value } from 'slate';
-
-// import Typography from '@material-ui/core/Typography';
-// import classNames from 'classnames';
 
 const drawerWidth = 240;
 
@@ -50,12 +45,12 @@ const styles = theme => ({
     }),
   },
   'appBarShift-left': {
-    // marginLeft: drawerWidth,
-    marginLeft: 0
+    marginLeft: drawerWidth,
+    // marginLeft: 0
   },
   'appBarShift-right': {
-    // marginRight: drawerWidth,
-    marginLeft: 0
+    marginRight: drawerWidth,
+    // marginLeft: 0
   },
   menuButton: {
     padding: '5px',
@@ -68,12 +63,14 @@ const styles = theme => ({
     position: 'relative',
     display: 'block',
     [theme.breakpoints.down('sm')]: {
-      width: '100%'
+      width: '100%',
+      height: '100vh',
     },
     [theme.breakpoints.up('md')]: {
-      width: '240px'
+      // width: '240px',
+      minWidth: '225px',
+      height: `calc(100vh - 74px)`
     },
-    height: `calc(100vh - 74px)`
   },
   headerPaper: {
     position: 'relative',
@@ -82,7 +79,8 @@ const styles = theme => ({
       width: '100%'
     },
     [theme.breakpoints.up('md')]: {
-      width: '240px'
+      // width: '240px'
+      minWidth: '225px',
     },
   },
   drawerHeaderL: {
@@ -112,8 +110,6 @@ class LeftDrawer extends Component {
     this.handleNewNote = this.handleNewNote.bind(this);
     this.handleSelectedNote = this.props.handleSelectedNote.bind(this);
     this.handleDeleteAlert = this.props.handleDeleteAlert.bind(this);
-    // this.handleSelectedIndex = this.handleSelectedIndex.bind(this);
-    // this.handleSharedIndex = this.handleSharedIndex.bind(this);
     this.child = React.createRef();
   }
 

--- a/client/src/components/LeftDrawer/LeftDrawer.js
+++ b/client/src/components/LeftDrawer/LeftDrawer.js
@@ -103,6 +103,8 @@ class LeftDrawer extends Component {
     body: "",
     notes: [],
     email: "",
+    selectedIndex: null,
+    selectedSharedIndex: null,
   }
 
   constructor(props) {
@@ -110,6 +112,8 @@ class LeftDrawer extends Component {
     this.handleNewNote = this.handleNewNote.bind(this);
     this.handleSelectedNote = this.props.handleSelectedNote.bind(this);
     this.handleDeleteAlert = this.props.handleDeleteAlert.bind(this);
+    // this.handleSelectedIndex = this.handleSelectedIndex.bind(this);
+    // this.handleSharedIndex = this.handleSharedIndex.bind(this);
     this.child = React.createRef();
   }
 
@@ -152,6 +156,19 @@ class LeftDrawer extends Component {
       .then(this.child.current.refreshNewNote(this.state.email));
   };
 
+  handleSelectedIndex = (index) => {
+    console.log(index);
+    console.log("LEFTDRAWER HANDLE SELECTED INDEX FUNCTION")
+    // console.log(this.state.selectedIndex);
+    this.setState({ selectedIndex: index, selectedSharedIndex: null });
+  }
+
+  handleSharedIndex = (index) => {
+    console.log(index);
+    console.log(this.state.selectedSharedIndex);
+    this.setState({ selectedSharedIndex: index, selectedIndex: null })
+  }
+
   render() {
     const { classes } = this.props;
 
@@ -163,10 +180,14 @@ class LeftDrawer extends Component {
           handleSelectedNote={this.handleSelectedNote}
           handleDeleteAlert={this.props.handleDeleteAlert}
           innerRef={this.child}
+          selectedIndex={this.state.selectedIndex}
+          handleSelectedIndex={this.handleSelectedIndex}
         />
         <SharedNotes
-        notes={this.state.notes}
-        handleSelectedNote={this.handleSelectedNote}
+          notes={this.state.notes}
+          handleSelectedNote={this.handleSelectedNote}
+          selectedSharedIndex={this.state.selectedSharedIndex}
+          handleSharedIndex={this.handleSharedIndex}
         />
       </>
     )

--- a/client/src/components/NoteArea.js
+++ b/client/src/components/NoteArea.js
@@ -7,7 +7,14 @@ import API from "../utils/API";
 import {firebase} from '../firebase';
 
 import Paper from '@material-ui/core/Paper';
+import { withStyles } from '@material-ui/core/styles';
 
+const styles = {
+  scroll: {
+    overflowY: 'scroll',
+    height: 'calc(100vh - 90px)'
+  }
+}
 
 const initialValue = Value.fromJSON({
   document: {
@@ -88,17 +95,19 @@ class NoteArea extends React.Component {
 
   // Render the editor.
   render() {
+    const { classes } = this.props;
     // return <Editor value={this.state.value} onChange={this.onChange} />
     return(
       <Paper>
-      <Editor 
+      <Editor
+        className={classes.scroll} 
         value={this.state.value} 
         onChange={this.onChange}
         style={{
           'minHeight':'calc(100vh - 90px)',
           margin: '20px 0 30px 0',
           padding: '10px',
-          color: this.props.text
+          color: this.props.text,
         }}
       />
       </Paper>
@@ -106,4 +115,4 @@ class NoteArea extends React.Component {
   }
 }
 
-export default NoteArea;
+export default withStyles(styles)(NoteArea);

--- a/client/src/components/NoteArea.js
+++ b/client/src/components/NoteArea.js
@@ -2,7 +2,7 @@
 import React from 'react';
 import { Editor } from 'slate-react';
 import { Value } from 'slate';
-import API from "../utils/API";
+import API from '../utils/API';
 // import AuthUserContext from './AuthUserContext';
 import {firebase} from '../firebase';
 

--- a/client/src/components/NoteList/NoteList.js
+++ b/client/src/components/NoteList/NoteList.js
@@ -26,9 +26,7 @@ import ExpandMore from '@material-ui/icons/ExpandMore';
 import Fade from '@material-ui/core/Fade';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import FolderSharp from '@material-ui/icons/FolderSharp';
-import FolderSharedSharp from '@material-ui/icons/FolderSharedSharp';
 import InsertDriveFileOutlined from '@material-ui/icons/InsertDriveFileOutlined'
-
 
 const styles = theme => ({
   root: {
@@ -38,16 +36,6 @@ const styles = theme => ({
     marginRight: theme.spacing.unit * 2,
     justifyContent: 'flex-end',
   },
-  // menuItem: {
-  //   '&:focus': {
-  //     backgroundColor: theme.palette.primary.main,
-  //     '& $primary, & $icon': {
-  //       color: theme.palette.common.white,
-  //     },
-  //   },
-  // },
-  // primary: {},
-  // icon: {},
   noteField: {
     justifyContent: 'flex-end',
     width: '100%',
@@ -64,9 +52,15 @@ const styles = theme => ({
   },
   noteFieldEditInput: {
     paddingBottom: '10px',
+    '&:after': {
+      borderBottom: 'none',
+    },
+    '&:before': {
+      borderBottom: 'none',
+    }
   },
   noteFieldIcon: {
-    paddingTop: '10px',
+    transform: 'translate(-10px,5px)'
   },
   noteListItem: {
     padding: '0',
@@ -93,6 +87,7 @@ function getModalStyle() {
 
 class NoteList extends Component {
   state = {
+    isMounted: false,
     notes: this.props.notes, // does this even do anything?
     isEditable: [],
     val: [],
@@ -108,16 +103,21 @@ class NoteList extends Component {
     toggleShared: true,
     isLoading: false,
     selectedIndex: null, // index of the selected note, default to null or -1?
-  };  
+  };
 
   componentDidMount() {
-    firebase.auth.onAuthStateChanged(authUser => {
-      if (authUser != null) this.setState({ email: authUser.email, isLoading: true }, function() {
-        this.loadNotes();
+    this.setState({ isMounted: true }, () => {
+      firebase.auth.onAuthStateChanged(authUser => {
+        if (authUser != null && this.state.isMounted) this.setState({ email: authUser.email, isLoading: true }, function() {
+          this.loadNotes();
+        })
       })
-    })
+    });
     console.log("NoteList.js componentDidMount()")
+  }
 
+  componentWillUnount() {
+    this.setState({ isMounted: false });
   }
 
   // is this necessary? 
@@ -232,6 +232,7 @@ class NoteList extends Component {
         let edit = this.state.isEditable.map((val) => {
           return (val = false);
         });
+        this.handleSelectedIndex(0);
         let isEditable = edit.slice();
         isEditable[0] = true;
         this.setState({ isEditable });
@@ -340,20 +341,19 @@ class NoteList extends Component {
         {this.state.notes.map((note, index) => {
           return (
           // <>
-          <Collapse in={this.state.toggleNotes} timeout="auto" unmountOnExit>
-            {/* <List component="div" disablePadding> */}
+          <Collapse in={this.state.toggleNotes} timeout="auto" unmountOnExit key={note._id}>
             <List component="div" disablePadding>
-            {/* <ListItem button className={classes.nested}> */}
-            <ListItem 
-              button 
-              className={[classes.nested, classes.noteListItem]}
+            <ListItem
+              button
+              // className={[classes.nested, classes.noteListItem]}
+              className={`${classes.nested} ${classes.noteListItem}`}
               selected={this.state.selectedIndex === index}
             >
             {this.state.isEditable[index] ? (
               // Editable text field
-              // <div key={note._id}>
               <TextField
-                className={[classes.noteField, classes.noteFieldEdit]}
+                // className={[classes.noteField, classes.noteFieldEdit]}
+                className={`${classes.noteField} ${classes.noteFieldEdit}`}
                 key={note._id}
                 autoFocus={true}
                 onFocus={this.handleFocus}
@@ -454,21 +454,26 @@ class NoteList extends Component {
               Who Do You Want To Share With?
             </Typography>
             <TextField
-          id="standard-full-width"
-          label="Please enter an email below"
-          style={{ margin: 8 }}
-          placeholder="Email Address"
-          fullWidth
-          margin="normal"
-          InputLabelProps={{
-            shrink: true,
-          }}
-          onChange={(event) => this.handleShareChange(event)}
-        />
-                  <Button variant="contained" color="primary" className={classes.button} onClick={() => this.handleSharedSubmit()}>
-        Add User
-      </Button>
-          </div>
+              id="standard-full-width"
+              label="Please enter an email below"
+              style={{ margin: 8 }}
+              placeholder="Email Address"
+              fullWidth
+              margin="normal"
+              InputLabelProps={{
+                shrink: true,
+              }}
+              onChange={(event) => this.handleShareChange(event)}
+            />
+          <Button 
+            variant="contained"
+            color="default"
+            className={classes.button}
+            onClick={() => this.handleSharedSubmit()}
+          >
+            Share
+          </Button>
+        </div>
         </Modal>
         </>
       ) : (

--- a/client/src/components/NoteList/NoteList.js
+++ b/client/src/components/NoteList/NoteList.js
@@ -73,7 +73,7 @@ const styles = theme => ({
     paddingLeft: '12%', // Not an ideal solution
   },
   input: {
-    cursor: 'pointer !important',
+    cursor: 'default !important',
   },
   itemText: {
     padding: '0',
@@ -105,7 +105,8 @@ class NoteList extends Component {
     sharedUser: null,
     toggleNotes: true,
     toggleShared: true,
-    isLoading: false
+    isLoading: false,
+    selectedIndex: null, // index of the selected note, default to null or -1?
   };  
 
   componentDidMount() {
@@ -258,6 +259,10 @@ class NoteList extends Component {
     .catch(err => console.log(err));
   }
 
+  handleSelectedIndex = (index) => {
+    this.setState({ selectedIndex: index });
+  }
+
   handleOpenModal = (event) => {
     event.preventDefault();
     this.handleCloseContext(event);
@@ -315,7 +320,11 @@ class NoteList extends Component {
             {/* <List component="div" disablePadding> */}
             <List component="div" disablePadding>
             {/* <ListItem button className={classes.nested}> */}
-            <ListItem button className={[classes.nested, classes.noteListItem]}>
+            <ListItem 
+              button 
+              className={[classes.nested, classes.noteListItem]}
+              selected={this.state.selectedIndex === index}
+            >
             {this.state.isEditable[index] ? (
               // Editable text field
               // <div key={note._id}>
@@ -335,9 +344,6 @@ class NoteList extends Component {
                     <ListItemIcon className={classes.noteFieldIcon} position="start">
                       <InsertDriveFileOutlined />
                     </ListItemIcon>
-                    // <InputAdornment className={classes.noteFieldIcon} position="start">
-                    //   <InsertDriveFileOutlined />
-                    // </InputAdornment>
                   ),
                 }}
               />
@@ -346,22 +352,19 @@ class NoteList extends Component {
               <TextField
                 className={classes.noteField}
                 key={note._id}
+                selected={this.state.selected}
                 InputProps={{
                   readOnly: true,
                   className: classes.input,
-                  // style: {cursor: 'pointer !important'},
                   disableUnderline: true,
                   startAdornment: (
-                    // <InputAdornment position="start">
-                    //   <InsertDriveFileOutlined />
-                    // </InputAdornment>
                     <ListItemIcon position="start">
                       <InsertDriveFileOutlined />
                     </ListItemIcon>
                   ),
                 }}
                 defaultValue={note.title}
-                onClick={() => this.handleSelectRefresh(note._id)}
+                onClick={() => {this.handleSelectRefresh(note._id); this.handleSelectedIndex(index); }}
                 onDoubleClick={(e) => this.handleDoubleClick(e, index)}
                 aria-owns={contextOpen ? 'simple-menu' : null}
                 aria-haspopup="true"

--- a/client/src/components/NoteList/NoteList.js
+++ b/client/src/components/NoteList/NoteList.js
@@ -3,8 +3,8 @@ import API from '../../utils/API';
 import Button from '@material-ui/core/Button';
 import TextField from '@material-ui/core/TextField';
 import Modal from '@material-ui/core/Modal';
-import Typography from "@material-ui/core/Typography";
-import {firebase} from "../../firebase";
+import Typography from '@material-ui/core/Typography';
+import {firebase} from '../../firebase';
 import PropTypes from 'prop-types';
 import MenuList from '@material-ui/core/MenuList';
 import MenuItem from '@material-ui/core/MenuItem';
@@ -15,7 +15,6 @@ import ListItemIcon from '@material-ui/core/ListItemIcon';
 import ListItemText from '@material-ui/core/ListItemText';
 import ClickAwayListener from '@material-ui/core/ClickAwayListener';
 import Popover from '@material-ui/core/Popover';
-import SharedNotes from "../SharedNotes/SharedNotes";
 
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
@@ -26,7 +25,8 @@ import ExpandMore from '@material-ui/icons/ExpandMore';
 import Fade from '@material-ui/core/Fade';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import FolderSharp from '@material-ui/icons/FolderSharp';
-import InsertDriveFileOutlined from '@material-ui/icons/InsertDriveFileOutlined'
+import InsertDriveFileOutlined from '@material-ui/icons/InsertDriveFileOutlined';
+import green from '@material-ui/core/colors/green';
 
 const styles = theme => ({
   root: {
@@ -71,7 +71,11 @@ const styles = theme => ({
   },
   itemText: {
     padding: '0',
-  }
+    font: '12px',
+  },
+  collapsers: {
+    marginRight: '0',
+  },
 });
 
 function getModalStyle() {
@@ -220,8 +224,6 @@ class NoteList extends Component {
   };
 
   loadNotes = () => {
-    console.log('Ran loadNotes function from NoteList.js.')
-    console.log(this.state.email);
     API.getNotes(this.state.email)
       .then(res => this.setState({ notes: res.data }, () => this.setState({ isLoading: false })))
       .catch(err => console.log(err));    
@@ -337,15 +339,15 @@ class NoteList extends Component {
       {this.state.notes.length ? (
         <>
         <List>
-        <ListItem button onClick={this.handleNotesToggle}>
-          <ListItemIcon>
-            <FolderSharp />
-          </ListItemIcon>
-          <ListItemText className={classes.itemText} primary="My notes" />
-          <ListItemIcon>
-            {this.state.toggleNotes ? <ExpandLess /> : <ExpandMore />}
-          </ListItemIcon>
-        </ListItem>
+          <ListItem button onClick={this.handleNotesToggle}>
+            <ListItemIcon>
+              <FolderSharp />
+            </ListItemIcon>
+            <ListItemText className={classes.itemText} primary="My notes" />
+            <ListItemIcon className={classes.collapsers}>
+              {this.state.toggleNotes ? <ExpandLess /> : <ExpandMore />}
+            </ListItemIcon>
+          </ListItem>
         {this.state.notes.map((note, index) => {
           return (
           // <>
@@ -353,14 +355,12 @@ class NoteList extends Component {
             <List component="div" disablePadding>
             <ListItem
               button
-              // className={[classes.nested, classes.noteListItem]}
               className={`${classes.nested} ${classes.noteListItem}`}
               selected={this.state.selectedIndex === index}
             >
             {this.state.isEditable[index] ? (
               // Editable text field
               <TextField
-                // className={[classes.noteField, classes.noteFieldEdit]}
                 className={`${classes.noteField} ${classes.noteFieldEdit}`}
                 key={note._id}
                 autoFocus={true}
@@ -494,7 +494,7 @@ class NoteList extends Component {
             }}
             unmountOnExit
           >
-            <CircularProgress />
+            <CircularProgress style={{ color: green[500] }}/>
           </Fade>
         ) : (
           <p>No notes to display.</p>

--- a/client/src/components/NoteList/NoteList.js
+++ b/client/src/components/NoteList/NoteList.js
@@ -102,7 +102,7 @@ class NoteList extends Component {
     toggleNotes: true,
     toggleShared: true,
     isLoading: false,
-    selectedIndex: null, // index of the selected note, default to null or -1?
+    selectedIndex: this.props.selectedIndex,
   };
 
   componentDidMount() {
@@ -128,6 +128,13 @@ class NoteList extends Component {
   //     this.setState({notes: this.props.notes});
   //   }
   // }
+
+  componentDidUpdate(prevProps) {
+    if (this.props.selectedIndex !== prevProps.selectedIndex) {
+      this.setState({ selectedIndex: this.props.selectedIndex });
+      console.log("component did update index: " + this.props.selectedIndex);
+    }
+  }
 
   handleDoubleClick (event, index) {
     let edit = this.state.isEditable.map((val, index) => {
@@ -232,7 +239,7 @@ class NoteList extends Component {
         let edit = this.state.isEditable.map((val) => {
           return (val = false);
         });
-        this.handleSelectedIndex(0);
+        this.props.handleSelectedIndex(0);
         let isEditable = edit.slice();
         isEditable[0] = true;
         this.setState({ isEditable });
@@ -262,9 +269,9 @@ class NoteList extends Component {
     .catch(err => console.log(err));
   }
 
-  handleSelectedIndex = (index) => {
-    this.setState({ selectedIndex: index });
-  }
+  // handleSelectedIndex = (index) => {
+  //   this.setState({ selectedIndex: index });
+  // }
 
   handleOpenModal = (event) => {
     event.preventDefault();
@@ -289,7 +296,8 @@ class NoteList extends Component {
       }
       let note = this.state.notes[index]
       this.props.handleSelectedNote(note._id, note.content);
-      this.handleSelectedIndex(index);
+      // this.handleSelectedIndex(index);
+      this.props.handleSelectedIndex(index);
     }))
     .catch(err => console.log(err));
   }
@@ -388,7 +396,7 @@ class NoteList extends Component {
                   ),
                 }}
                 defaultValue={note.title}
-                onClick={() => {this.handleSelectRefresh(note._id); this.handleSelectedIndex(index); }}
+                onClick={() => {this.handleSelectRefresh(note._id); this.props.handleSelectedIndex(index); }}
                 onDoubleClick={(e) => this.handleDoubleClick(e, index)}
                 aria-owns={contextOpen ? 'simple-menu' : null}
                 aria-haspopup="true"

--- a/client/src/components/Page/MainPage.js
+++ b/client/src/components/Page/MainPage.js
@@ -113,7 +113,7 @@ class MainPage extends React.Component {
               deleteAlertOpen={this.state.deleteAlertOpen}
               handleAlertClose={this.handleAlertClose}
             />
-            <Grid container className={classes.scroll}>
+            <Grid container>
               <Grid item md={2}>
                 <LeftDrawer
                   leftOpen={this.state.leftOpen}

--- a/client/src/components/Page/MainPage.js
+++ b/client/src/components/Page/MainPage.js
@@ -113,7 +113,7 @@ class MainPage extends React.Component {
               deleteAlertOpen={this.state.deleteAlertOpen}
               handleAlertClose={this.handleAlertClose}
             />
-            <Grid container>
+            <Grid container spacing={32}>
               <Grid item md={2}>
                 <LeftDrawer
                   leftOpen={this.state.leftOpen}
@@ -123,7 +123,7 @@ class MainPage extends React.Component {
                 />
               </Grid>
 
-              <Grid item md={8}>
+              <Grid item md={9} xs={12}>
                 <main>
                   <Content
                     selectedNoteID={this.state.selectedNoteID}

--- a/client/src/components/PasswordChange.js
+++ b/client/src/components/PasswordChange.js
@@ -17,7 +17,7 @@ const styles = theme => ({
     marginRight: theme.spacing.unit * 3,
     [theme.breakpoints.up(400 + theme.spacing.unit * 3 * 2)]: {
       width: 400,
-      // marginLeft: 'auto',
+      marginLeft: 'auto',
       marginRight: 'auto',
     },
   },
@@ -110,8 +110,14 @@ class PasswordChangeForm extends Component {
             className={classes.textField}
           />          
         </FormControl>
-        <Button disabled={isInvalid} type="submit" variant="contained" color="primary" className={classes.submit}>
-          Reset My Password
+        <Button 
+          disabled={isInvalid} 
+          type="submit"
+          fullWidth
+          variant="contained"
+          color="default"
+          className={classes.submit}>
+          Change Password
         </Button>
       </form>
       </main>

--- a/client/src/components/SharedNotes/SharedNotes.js
+++ b/client/src/components/SharedNotes/SharedNotes.js
@@ -62,10 +62,16 @@ const styles = theme => ({
     height: '35px',
   },
   noteFieldEditInput: {
-    paddingBottom: '10px'
+    paddingBottom: '10px',
+    '&:after': {
+      borderBottom: 'none',
+    },
+    '&:before': {
+      borderBottom: 'none',
+    }
   },
   noteFieldIcon: {
-    paddingTop: '10px'
+    transform: 'translate(-10px,5px)'
   },
   noteListItem: {
     padding: '0',
@@ -283,10 +289,7 @@ class SharedNotes extends Component {
   render() {
     const { classes } = this.props;
     const {
-      targetId,
       contextOpen,
-      positionTop,
-      positionLeft,
     } = this.state;
 
     return(
@@ -295,21 +298,24 @@ class SharedNotes extends Component {
         <>
         <List>
         <ListItem button onClick={this.handleSharedToggle}>
-            <ListItemIcon>
-              <FolderSharedSharp />
-            </ListItemIcon>
-            <ListItemText className={classes.itemText} primary="Shared with me" />
-            {this.state.toggleShared ? <ExpandLess /> : <ExpandMore />}
-          </ListItem>
+          <ListItemIcon>
+            <FolderSharedSharp />
+          </ListItemIcon>
+          <ListItemText className={classes.itemText} primary="Shared with me" />
+          {this.state.toggleShared ? <ExpandLess /> : <ExpandMore />}
+        </ListItem>
         {this.state.notes.map((note, index) => {
           return (
-            <Collapse in={this.state.toggleShared} timeout="auto" unmountOnExit>
+            <Collapse in={this.state.toggleShared} timeout="auto" unmountOnExit key={note._id}>
             <List component="div" disablePadding>
-              <ListItem button className={[classes.nested, classes.noteListItem]}>
+              <ListItem 
+                button 
+                // className={[classes.nested, classes.noteListItem]}
+                className={`${classes.nested} ${classes.noteListItem}`}
+              >
               <TextField
                 className={classes.noteField}
                 key={note._id}
-                // variant="filled"
                 InputProps={{
                   readOnly: true,
                   className: classes.input,
@@ -322,7 +328,6 @@ class SharedNotes extends Component {
                 }}
                 defaultValue={note.title}
                 onClick={() => this.handleSelectRefresh(note._id)}
-                // onDoubleClick={(e) => this.handleDoubleClick(e, index)}
                 aria-owns={contextOpen ? 'simple-menu' : null}
                 aria-haspopup="true"
                 onContextMenu={(e) => this.handleContextMenu(e, note._id)}

--- a/client/src/components/SharedNotes/SharedNotes.js
+++ b/client/src/components/SharedNotes/SharedNotes.js
@@ -109,7 +109,8 @@ class SharedNotes extends Component {
     modalOpen: false,
     sharedUser: null,
     toggleShared: true,
-    isLoading: false
+    isLoading: false,
+    selectedSharedIndex: this.props.selectedSharedIndex,
   };  
 
   componentDidMount() {
@@ -120,6 +121,13 @@ class SharedNotes extends Component {
     })
     console.log("NoteList.js componentDidMount()")
 
+  }
+
+  componentDidUpdate(prevProps) {
+    if (this.props.selectedSharedIndex !== prevProps.selectedSharedIndex) {
+      this.setState({ selectedSharedIndex: this.props.selectedSharedIndex });
+      console.log("component did update index: " + this.props.selectedSharedIndex);
+    }
   }
 
   // is this necessary? 
@@ -223,26 +231,27 @@ class SharedNotes extends Component {
       .catch(err => console.log(err));    
   }
 
-  refreshNewNote = (email) => {
-    console.log('Ran refreshNewNote function from NoteList.js.');
-    API.getSharedNotes(email)
-      .then(res => this.setState({ notes: res.data }, () => {this.handleSelectRefresh(this.state.notes[0]._id);}))
-      .catch(err => console.log(err));
+  // refreshNewNote = (email) => {
+  //   console.log('Ran refreshNewNote function from NoteList.js.');
+  //   API.getSharedNotes(email)
+  //     .then(res => this.setState({ notes: res.data }, () => {this.handleSelectRefresh(this.state.notes[0]._id);}))
+  //     .catch(err => console.log(err));
 
-    // this seems clunky
-    setTimeout(
-      function() {
-        let edit = this.state.isEditable.map((val) => {
-          return (val = false);
-        });
-        let isEditable = edit.slice();
-        isEditable[0] = true;
-        this.setState({ isEditable });
-      }
-      .bind(this),
-      310
-    );
-  }
+  //   // this seems clunky
+  //   setTimeout(
+  //     function() {
+  //       let edit = this.state.isEditable.map((val) => {
+  //         return (val = false);
+  //       });
+  //       this.props.handleSelectedIndex(0);
+  //       let isEditable = edit.slice();
+  //       isEditable[0] = true;
+  //       this.setState({ isEditable });
+  //     }
+  //     .bind(this),
+  //     310
+  //   );
+  // }
 
   handleSharedToggle = () => {
     this.setState({ toggleShared: !this.state.toggleShared });
@@ -312,6 +321,7 @@ class SharedNotes extends Component {
                 button 
                 // className={[classes.nested, classes.noteListItem]}
                 className={`${classes.nested} ${classes.noteListItem}`}
+                selected={this.state.selectedSharedIndex === index}
               >
               <TextField
                 className={classes.noteField}
@@ -327,7 +337,7 @@ class SharedNotes extends Component {
                   ),
                 }}
                 defaultValue={note.title}
-                onClick={() => this.handleSelectRefresh(note._id)}
+                onClick={() => {this.handleSelectRefresh(note._id); this.props.handleSharedIndex(index); }}
                 aria-owns={contextOpen ? 'simple-menu' : null}
                 aria-haspopup="true"
                 onContextMenu={(e) => this.handleContextMenu(e, note._id)}

--- a/client/src/components/SharedNotes/SharedNotes.js
+++ b/client/src/components/SharedNotes/SharedNotes.js
@@ -1,31 +1,31 @@
 import React, { Component } from 'react';
 import API from '../../utils/API';
-import Button from '@material-ui/core/Button';
+// import Button from '@material-ui/core/Button';
 import TextField from '@material-ui/core/TextField';
-import Modal from '@material-ui/core/Modal';
-import Typography from "@material-ui/core/Typography";
-import {firebase} from "../../firebase";
+// import Modal from '@material-ui/core/Modal';
+// import Typography from "@material-ui/core/Typography";
+import {firebase} from '../../firebase';
 import PropTypes from 'prop-types';
-import MenuList from '@material-ui/core/MenuList';
-import MenuItem from '@material-ui/core/MenuItem';
-import DeleteIcon from '@material-ui/icons/Delete';
-import FolderShared from '@material-ui/icons/FolderShared';
+// import MenuList from '@material-ui/core/MenuList';
+// import MenuItem from '@material-ui/core/MenuItem';
+// import DeleteIcon from '@material-ui/icons/Delete';
+// import FolderShared from '@material-ui/icons/FolderShared';
 import { withStyles } from '@material-ui/core/styles';
 import ListItemIcon from '@material-ui/core/ListItemIcon';
 import ListItemText from '@material-ui/core/ListItemText';
-import ClickAwayListener from '@material-ui/core/ClickAwayListener';
-import Popover from '@material-ui/core/Popover';
-import Layers from '@material-ui/icons/Layers';
-import InputAdornment from '@material-ui/core/InputAdornment';
+// import ClickAwayListener from '@material-ui/core/ClickAwayListener';
+// import Popover from '@material-ui/core/Popover';
+// import Layers from '@material-ui/icons/Layers';
+// import InputAdornment from '@material-ui/core/InputAdornment';
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
 import Collapse from '@material-ui/core/Collapse';
 import ExpandLess from '@material-ui/icons/ExpandLess';
 import ExpandMore from '@material-ui/icons/ExpandMore';
 
-import Fade from '@material-ui/core/Fade';
-import CircularProgress from '@material-ui/core/CircularProgress';
-import FolderSharp from '@material-ui/icons/FolderSharp';
+// import Fade from '@material-ui/core/Fade';
+// import CircularProgress from '@material-ui/core/CircularProgress';
+// import FolderSharp from '@material-ui/icons/FolderSharp';
 import FolderSharedSharp from '@material-ui/icons/FolderSharedSharp';
 import InsertDriveFileOutlined from '@material-ui/icons/InsertDriveFileOutlined'
 
@@ -82,7 +82,10 @@ const styles = theme => ({
   },
   itemText: {
     padding: '0',
-  }
+  },
+  collapser: {
+    marginRight: '0',
+  },
 });
 
 function getModalStyle() {
@@ -224,10 +227,9 @@ class SharedNotes extends Component {
   };
 
   loadNotes = () => {
-    console.log('Ran loadNotes function from NoteList.js.')
     console.log(this.state.email);
     API.getSharedNotes(this.state.email)
-      .then(res => this.setState({ notes: res.data }, () => {console.log(this.state.notes)}))
+      .then(res => this.setState({ notes: res.data }))
       .catch(err => console.log(err));    
   }
 
@@ -302,57 +304,57 @@ class SharedNotes extends Component {
     } = this.state;
 
     return(
-      <>
+    <>
       {this.state.notes.length ? (
-        <>
+      <>
         <List>
-        <ListItem button onClick={this.handleSharedToggle}>
-          <ListItemIcon>
-            <FolderSharedSharp />
-          </ListItemIcon>
-          <ListItemText className={classes.itemText} primary="Shared with me" />
-          {this.state.toggleShared ? <ExpandLess /> : <ExpandMore />}
-        </ListItem>
+          <ListItem button onClick={this.handleSharedToggle}>
+            <ListItemIcon>
+              <FolderSharedSharp />
+            </ListItemIcon>
+            <ListItemText className={classes.itemText} primary="Shared with me" />
+            <ListItemIcon className={classes.collapser}>
+              {this.state.toggleShared ? <ExpandLess /> : <ExpandMore />}
+            </ListItemIcon>
+          </ListItem>
         {this.state.notes.map((note, index) => {
           return (
             <Collapse in={this.state.toggleShared} timeout="auto" unmountOnExit key={note._id}>
-            <List component="div" disablePadding>
-              <ListItem 
-                button 
-                // className={[classes.nested, classes.noteListItem]}
-                className={`${classes.nested} ${classes.noteListItem}`}
-                selected={this.state.selectedSharedIndex === index}
-              >
-              <TextField
-                className={classes.noteField}
-                key={note._id}
-                InputProps={{
-                  readOnly: true,
-                  className: classes.input,
-                  disableUnderline: true,
-                  startAdornment: (
-                    <ListItemIcon position="start">
-                      <InsertDriveFileOutlined />
-                    </ListItemIcon>
-                  ),
-                }}
-                defaultValue={note.title}
-                onClick={() => {this.handleSelectRefresh(note._id); this.props.handleSharedIndex(index); }}
-                aria-owns={contextOpen ? 'simple-menu' : null}
-                aria-haspopup="true"
-                onContextMenu={(e) => this.handleContextMenu(e, note._id)}
-              />
-              </ListItem>
-            </List>
-          </Collapse>
-          );
-        })}
-          </List>
-        </>
+              <List component="div" disablePadding>
+                <ListItem 
+                  button
+                  className={`${classes.nested} ${classes.noteListItem}`}
+                  selected={this.state.selectedSharedIndex === index}
+                >
+                <TextField
+                  className={classes.noteField}
+                  key={note._id}
+                  InputProps={{
+                    readOnly: true,
+                    className: classes.input,
+                    disableUnderline: true,
+                    startAdornment: (
+                      <ListItemIcon position="start">
+                        <InsertDriveFileOutlined />
+                      </ListItemIcon>
+                    ),
+                  }}
+                  defaultValue={note.title}
+                  onClick={() => {this.handleSelectRefresh(note._id); this.props.handleSharedIndex(index); }}
+                  aria-owns={contextOpen ? 'simple-menu' : null}
+                  aria-haspopup="true"
+                  onContextMenu={(e) => this.handleContextMenu(e, note._id)}
+                />
+                </ListItem>
+              </List>
+            </Collapse>
+            );
+          })}
+        </List>
+      </>
       ) : (
-        <>
+      <>
         {this.state.isLoading ? (
-
           <></>
         ) : (
           <></>

--- a/client/src/components/SignIn.js
+++ b/client/src/components/SignIn.js
@@ -149,7 +149,7 @@ class SignInForm extends Component {
                   type="submit"
                   fullWidth
                   variant="raised"
-                  color="primary"
+                  color="default"
                   className={classes.submit}
                 >
                   Sign in

--- a/client/src/components/SignUp.js
+++ b/client/src/components/SignUp.js
@@ -187,7 +187,7 @@ class SignUpForm extends Component {
                   type="submit"
                   fullWidth
                   variant="raised"
-                  color="primary"
+                  color="default"
                   className={classes.submit}
                 >
                   Create Account

--- a/client/src/components/TopNav/TopNav.js
+++ b/client/src/components/TopNav/TopNav.js
@@ -11,18 +11,7 @@ import AccountMenu from '../AccountMenu/AccountMenu';
 import AuthUserContext from '../AuthUserContext';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Switch from '@material-ui/core/Switch';
-
-// const theme = createMuiTheme({
-//   palette: {
-//     // type: 'dark',
-//     primary: {
-//       main: '#c8e6c9',
-//     },
-//     secondary: {
-//       main: '#e8f5e9',
-//     },
-//   },
-// });
+import Tooltip from '@material-ui/core/Tooltip';
 
 const styles = {
   root: {
@@ -58,26 +47,30 @@ class Navbar extends React.Component {
           {authUser => authUser
             ? (
             <>
-              <IconButton
-                color="inherit"
-                aria-label="Open left  drawer"
-                onClick={this.props.handleLeftDrawer}
-                className={classNames(classes.menuButton, this.props.leftOpen && classes.hide)}
-              >
-                <MenuSharp />
-              </IconButton>
+              <Tooltip title="Toggle notes panel">
+                <IconButton
+                  color="inherit"
+                  aria-label="Toggle notes panel"
+                  onClick={this.props.handleLeftDrawer}
+                  className={classNames(classes.menuButton, this.props.leftOpen && classes.hide)}
+                >
+                  <MenuSharp />
+                </IconButton>
+              </Tooltip>
               <Typography variant="title" color="inherit" style={{flex: 1}}>
                 GrantsNotes
               </Typography>
-              <FormControlLabel
-                control={
-                  <Switch
-                    onChange={this.props.handleThemeToggle}
-                    value="theme"
-                    color="default"
-                  />
-                }
-              />
+              <Tooltip title="Toggle theme">
+                <FormControlLabel
+                  control={
+                    <Switch
+                      onChange={this.props.handleThemeToggle}
+                      value="theme"
+                      color="default"
+                    />
+                  }
+                />
+              </Tooltip>
               <AccountMenu/>
             </>
             ) : (

--- a/client/src/components/TopNav/TopNav.js
+++ b/client/src/components/TopNav/TopNav.js
@@ -37,10 +37,7 @@ class Navbar extends React.Component {
 
     return(
       <AppBar position="static" color="default"
-        className={classNames(classes.appBar, {
-          [classes[`appBarShift-left`]]: this.props.leftOpen,
-          [classes[`appBarShift-right`]]: this.props.rightOpen
-        })}
+        className={classes.appBar}
       >
         <Toolbar className={classNames(classes.toolBar)}>
         <AuthUserContext.Consumer>

--- a/server.js
+++ b/server.js
@@ -14,8 +14,8 @@ app.use(bodyParser.json());
 
 app.use(express.static("public"));
 
-mongoose.connect(`mongodb://${process.env.USERNAME}:${process.env.PASSWORD}@ds117061.mlab.com:17061/heroku_7175wr6b`, {useNewUrlParser: true});
-
+// mongoose.connect(`mongodb://${process.env.USERNAME}:${process.env.PASSWORD}@ds117061.mlab.com:17061/heroku_7175wr6b`, {useNewUrlParser: true});
+mongoose.connect("mongodb://localhost/notes-app", {useNewUrlParser: true});
 require("./routes/html/html-routes")(app);
 
 app.use(routes);


### PR DESCRIPTION
**Note: in this branch I've re-added the localhost connection line in server.js and commented out the heroku connection. This was necessary for testing.  These will need to be switched if you want to deploy.**

- Fixed scroll issue with NoteArea by implementing a class instead of an inline style
- Added a handler that indicates which note you have selected. This is called by several actions now, since deleting and adding notes needed to interact with this (ie., creating a new note changes your selection to that note, and deleting a note changes your selection to whichever note will have the same index as the deleted one, or index-1 if it was the last note)
- Fixed a bug with the list item icons changing size when editing a note's title
- Added tooltips to a few of the app's icons/buttons
- Fixed errors thrown by classNames with multiple classes (needed to format it as a string rather than an array) from NoteList and SharedNotes
- Fixed error thrown by react expecting unique key props in NoteList and SharedNotes: the key needed to be applied to the highest element in the mapped return. I kept the original key values as well in case they're being used anywhere else - will check on this tomorrow.